### PR TITLE
Choose a random DNS entry instead of the first one

### DIFF
--- a/lib/net/tcp_client/tcp_client.rb
+++ b/lib/net/tcp_client/tcp_client.rb
@@ -512,11 +512,11 @@ module Net
         host_name, port = server.split(":")
         port            = port.to_i
 
-        address        = Socket.getaddrinfo(host_name, nil, Socket::AF_INET)
-        socket_address = Socket.pack_sockaddr_in(port, address[0][3])
+        address        = Socket.getaddrinfo(host_name, nil, Socket::AF_INET).sample
+        socket_address = Socket.pack_sockaddr_in(port, address[3])
 
         begin
-          @socket = Socket.new(Socket.const_get(address[0][0]), Socket::SOCK_STREAM, 0)
+          @socket = Socket.new(Socket.const_get(address[0]), Socket::SOCK_STREAM, 0)
           @socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1) unless buffered
           if @connect_timeout == -1
             # Timeout of -1 means wait forever for a connection

--- a/lib/net/tcp_client/tcp_client.rb
+++ b/lib/net/tcp_client/tcp_client.rb
@@ -512,7 +512,7 @@ module Net
         host_name, port = server.split(":")
         port            = port.to_i
 
-        address        = Socket.getaddrinfo(host_name, nil, Socket::AF_INET).sample
+        address        = Socket.getaddrinfo(host_name, nil, Socket::AF_INET, :STREAM).sample
         socket_address = Socket.pack_sockaddr_in(port, address[3])
 
         begin

--- a/lib/net/tcp_client/tcp_client.rb
+++ b/lib/net/tcp_client/tcp_client.rb
@@ -512,7 +512,7 @@ module Net
         host_name, port = server.split(":")
         port            = port.to_i
 
-        address        = Socket.getaddrinfo(host_name, nil, Socket::AF_INET, :STREAM).sample
+        address        = Socket.getaddrinfo(host_name, nil, Socket::AF_INET, Socket::SOCK_STREAM).sample
         socket_address = Socket.pack_sockaddr_in(port, address[3])
 
         begin


### PR DESCRIPTION
I think this behavior is better than what it did before but perhaps a "full" solution would be to try them all; it's not particularly relevant for my usecase as I'm fine as long as the load is somewhat distributed.