### PR TITLE
These constants are defined under the Socket module.

### DIFF
--- a/lib/net/tcp_client/tcp_client.rb
+++ b/lib/net/tcp_client/tcp_client.rb
@@ -569,7 +569,7 @@ module Net
         end
       unless buffered
         socket.sync = true
-        socket.setsockopt(IPPROTO_TCP, TCP_NODELAY, 1)
+        socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
       end
 
       socket_connect(socket, address, connect_timeout)


### PR DESCRIPTION
In order to make this run on my system, (Ruby 2.3.2p119 at the moment) I had to specify that the constants used in calling setsockopt are in the Socket module.  Without this, I get undefined constant errors.

This is a really useful project, thanks for making it available. I'm using it in a library for sending data to a Riemann server, and it's perfect for that.
