### PR TITLE
Semantic logger independence

### DIFF
--- a/lib/net/tcp_client/tcp_client.rb
+++ b/lib/net/tcp_client/tcp_client.rb
@@ -569,7 +569,7 @@ module Net
         socket.sync = true
         socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
       end
-      sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true) if keepalive
+      socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true) if keepalive
 
       socket_connect(socket, address, connect_timeout)
 

--- a/lib/net/tcp_client/tcp_client.rb
+++ b/lib/net/tcp_client/tcp_client.rb
@@ -319,7 +319,7 @@ module Net
           retry
         else
           message = "#connect Failed to connect to any of #{servers.join(',')} after #{retries} retries. #{exception.class}: #{exception.message}"
-          logger.benchmark_error(message, exception: exception, duration: (Time.now - start_time)) if respond_to?(:logger)
+          logger.benchmark_error(message, exception: exception, duration: (Time.now - start_time)) if respond_to?(:logger) && logger.is_a?(SemanticLogger::Logger)
           raise ConnectionFailure.new(message, address.to_s, cause)
         end
       end
@@ -348,7 +348,7 @@ module Net
     #        a new connection
     def write(data, timeout = write_timeout)
       data = data.to_s
-      if respond_to?(:logger)
+      if respond_to?(:logger) && logger.is_a?(SemanticLogger::Logger)
         payload        = {timeout: timeout}
         # With trace level also log the sent data
         payload[:data] = data if logger.trace?
@@ -400,7 +400,7 @@ module Net
     #        before calling _connect_ or _retry_on_connection_failure_ to create
     #        a new connection
     def read(length, buffer = nil, timeout = read_timeout)
-      if respond_to?(:logger)
+      if respond_to?(:logger) && logger.is_a?(SemanticLogger::Logger)
         payload = {bytes: length, timeout: timeout}
         logger.benchmark_debug('#read', payload: payload) do
           data           = socket_read(length, buffer, timeout)
@@ -494,7 +494,7 @@ module Net
 
     def flush
       return unless socket
-      respond_to?(:logger) ? logger.benchmark_debug('#flush') { socket.flush } : socket.flush
+      respond_to?(:logger) && logger.is_a?(SemanticLogger::Logger) ? logger.benchmark_debug('#flush') { socket.flush } : socket.flush
     end
 
     def closed?

--- a/test/policy/random_policy_test.rb
+++ b/test/policy/random_policy_test.rb
@@ -23,7 +23,7 @@ class Net::TCPClient::Policy::RandomTest < Minitest::Test
         # Keep retrying until the order is different.
         3.times do
           policy.each { |address| names << address.host_name }
-          break if names != %w(localhost:80 127.0.0.1:2000 lvh.me:2100)
+          break if names != %w(localhost 127.0.0.1 lvh.me)
           names = []
         end
 


### PR DESCRIPTION
Two things:

* Let Semantic Logger be a softer dependency
  We stumbled upon this because for instance, the standard Ruby 2.3 logger does neither have `#trace?`, `#benchmark_error`, nor `#benchmark_debug`.
* `sock` vs. `socket`
  I stumbled upon this while testing the above. It seems like a typo introduced back when introducing the keep alive functionality in 557c25579cd8a09854e5c72c12c9fca264c5f21e.